### PR TITLE
Fix ERR_STREAM_UNABLE_TO_PIPE in clean_unescaped_quotes

### DIFF
--- a/telestaff-payroll/src/clean_unescaped_quotes.js
+++ b/telestaff-payroll/src/clean_unescaped_quotes.js
@@ -11,23 +11,28 @@ function clean_unescaped_quotes_row(line) {
     .replace(/\|%\|/g, '"'); // restore first and last quotes
 }
 
-const clean_unescaped_quotes = new Transform({
-  transform(chunk, encoding, callback) {
-    this.remaining = (this.remaining || '') + chunk.toString();
-    const lines = this.remaining.split(/\r\n|\r|\n/);
-    this.remaining = lines.pop(); // Save the last incomplete line to be processed with the next chunk
-    for (const line of lines) {
-      this.push(clean_unescaped_quotes_row(line)+ '\n');
+// Return a fresh Transform each call. A Transform stream can only be consumed
+// once, so a shared singleton would fail (ERR_STREAM_UNABLE_TO_PIPE) on the
+// second file when it's reused after the first pipeline has ended it.
+function clean_unescaped_quotes() {
+  return new Transform({
+    transform(chunk, encoding, callback) {
+      this.remaining = (this.remaining || '') + chunk.toString();
+      const lines = this.remaining.split(/\r\n|\r|\n/);
+      this.remaining = lines.pop(); // Save the last incomplete line to be processed with the next chunk
+      for (const line of lines) {
+        this.push(clean_unescaped_quotes_row(line)+ '\n');
+      }
+      callback();
+    },
+    flush(callback) {
+      if (this.remaining) {
+        this.push(clean_unescaped_quotes_row(this.remaining)+ '\n');
+      }
+      callback();
     }
-    callback();
-  },
-  flush(callback) {
-    if (this.remaining) {
-      this.push(clean_unescaped_quotes_row(line)+ '\n');
-    }
-    callback();
-  }
-});
+  });
+}
 
 export default clean_unescaped_quotes;
 

--- a/telestaff-payroll/src/load_one_file.js
+++ b/telestaff-payroll/src/load_one_file.js
@@ -54,7 +54,7 @@ async function load_one_file(sql, filenm, tablenm) {
     // Pipe file downloaded from S3 to DB
     await pipeline(
         s3_stream,
-        clean_unescaped_quotes, // doubles unescaped quotes
+        clean_unescaped_quotes(), // doubles unescaped quotes
         _parse({  // parse csv into object of strings
           bom: true,
           columns: true,


### PR DESCRIPTION
Convert clean_unescaped_quotes from a reused module-level Transform to a
factory that returns a fresh stream per file; a stream can only be
consumed once, so the second file in a batch failed. Also fix flush()
referencing an undefined `line` variable.